### PR TITLE
Update hangul encoding to UTF-8

### DIFF
--- a/src/Editor/Modules/Core/SecurityBuildPipeline.cs
+++ b/src/Editor/Modules/Core/SecurityBuildPipeline.cs
@@ -12,6 +12,7 @@ namespace UGS.Editor
 
         }
 
+
         public void OnPreprocessBuild(BuildReport report)
         {
             var confirm = UnityEditor.EditorPrefs.GetBool("UGS.BuildMsg", false);

--- a/src/Editor/Modules/Core/SecurityBuildPipeline.cs
+++ b/src/Editor/Modules/Core/SecurityBuildPipeline.cs
@@ -12,14 +12,13 @@ namespace UGS.Editor
 
         }
 
-
         public void OnPreprocessBuild(BuildReport report)
         {
             var confirm = UnityEditor.EditorPrefs.GetBool("UGS.BuildMsg", false);
             if (!confirm)
             {
-                string x = "�о��ּ���! ���ȸ�尡 Ȱ��ȭ �Ǿ����� ������� ��ũ��Ʈ ���ð� UGS ���̺� ��ɵ��� �״�� �����մϴ�. ������ ������ ����Ϸ��� �ϴ°�� ���ȿɼ��� Ȱ��ȭ�ؾ��մϴ�. �ڼ��Ѱ� UGS�� ���ø޴��� �����۸�ũ���� Ȯ�����ּ���. ���� �׽�Ʈ�� ���� ���� ������ �� �޽����� �����ϼŵ� �˴ϴ�.";
-                var res = UnityEditor.EditorUtility.DisplayDialog("UGS Warning", x, "�����߽��ϴ�.");
+                string x = "읽어주세요! 보안모드가 활성화 되어있지 않은경우 스크립트 세팅과 UGS 라이브 기능등이 그대로 동작합니다. 게임을 실제로 출시하려고 하는경우 보안옵션을 활성화해야합니다. 자세한건 UGS의 세팅메뉴의 하이퍼링크에서 확인해주세요. 만약 테스트를 위한 개발 빌드라면 이 메시지를 무시하셔도 됩니다.";
+                var res = UnityEditor.EditorUtility.DisplayDialog("UGS Warning", x, "이해했습니다.");
                 if (res)
                 {
                     UnityEditor.EditorPrefs.SetBool("UGS.BuildMsg", true);


### PR DESCRIPTION
macOS Unity 2021.3 에서 빌드 시 해당 파일의 encoding 이슈로 editor가 crash되는 이슈를 수정합니다.